### PR TITLE
Fix the overflow of the to_checksum variable

### DIFF
--- a/lib/logstash/filters/checksum.rb
+++ b/lib/logstash/filters/checksum.rb
@@ -25,25 +25,25 @@ class LogStash::Filters::Checksum < LogStash::Filters::Base
   public
   def register
     require 'openssl'
-    @to_checksum = ""
   end
 
   public
   def filter(event)
     return unless filter?(event)
+    to_checksum = ""
 
     @logger.debug("Running checksum filter", :event => event)
 
     @keys.sort.each do |k|
       @logger.debug("Adding key to string", :current_key => k)
-      @to_checksum << "|#{k}|#{event[k]}"
+      to_checksum << "|#{k}|#{event[k]}"
     end
-    @to_checksum << "|"
-    @logger.debug("Final string built", :to_checksum => @to_checksum)
+    to_checksum << "|"
+    @logger.debug("Final string built", :to_checksum => to_checksum)
 
 
     # in JRuby 1.7.11 outputs as ASCII-8BIT
-    digested_string = OpenSSL::Digest.hexdigest(@algorithm, @to_checksum).force_encoding(Encoding::UTF_8)
+    digested_string = OpenSSL::Digest.hexdigest(@algorithm, to_checksum).force_encoding(Encoding::UTF_8)
 
     @logger.debug("Digested string", :digested_string => digested_string)
     event['logstash_checksum'] = digested_string

--- a/lib/logstash/filters/checksum.rb
+++ b/lib/logstash/filters/checksum.rb
@@ -36,9 +36,8 @@ class LogStash::Filters::Checksum < LogStash::Filters::Base
 
     @keys.sort.each do |k|
       @logger.debug("Adding key to string", :current_key => k)
-      to_checksum << "|#{k}|#{event[k]}"
+      to_checksum << "#{event[k]}"
     end
-    to_checksum << "|"
     @logger.debug("Final string built", :to_checksum => to_checksum)
 
 


### PR DESCRIPTION
Variable to_checksum should be local and cleared at every event to calculate checksums only from that event/message. 
