### PR TITLE
Fix abandoned test suite after changes introduced a while ago.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,5 @@
+# 1.0.1
+
+ * Fixes the test suites as they where expecting the formed way of
+   encoding.
+

--- a/logstash-filter-checksum.gemspec
+++ b/logstash-filter-checksum.gemspec
@@ -1,7 +1,7 @@
 Gem::Specification.new do |s|
 
   s.name            = 'logstash-filter-checksum'
-  s.version         = '1.0.0'
+  s.version         = '1.0.1'
   s.licenses        = ['Apache License (2.0)']
   s.summary         = "This filter let's you create a checksum based on various parts of the logstash event."
   s.description     = "This gem is a logstash plugin required to be installed on top of the Logstash core pipeline using $LS_HOME/bin/plugin install gemname. This gem is not a stand-alone program"

--- a/spec/filters/checksum_spec.rb
+++ b/spec/filters/checksum_spec.rb
@@ -19,7 +19,7 @@ describe LogStash::Filters::Checksum do
 
       sample "test" => "foo bar" do
         insist { !subject["logstash_checksum"].nil? }
-        insist { subject["logstash_checksum"] } == OpenSSL::Digest.hexdigest(alg, "|test|foo bar|")
+        insist { subject["logstash_checksum"] } == OpenSSL::Digest.hexdigest(alg, "foo bar")
       end
     end
 
@@ -35,7 +35,7 @@ describe LogStash::Filters::Checksum do
 
       sample "test1" => "foo", "test2" => "bar" do
         insist { !subject["logstash_checksum"].nil? }
-        insist { subject["logstash_checksum"] } == OpenSSL::Digest.hexdigest(alg, "|test1|foo|test2|bar|")
+        insist { subject["logstash_checksum"] } == OpenSSL::Digest.hexdigest(alg, "foobar")
       end
     end
   end


### PR DESCRIPTION
 Fix test after changes introduced by https://github.com/logstash-plugins/logstash-filter-checksum/commit/acb0b82e6f3e995d3c8a588392082bc776cbe789. This test has been failing since then as the test where not adapted accordingly.
